### PR TITLE
Fix gnosh deploy script

### DIFF
--- a/script/Deploy.gnosh.s.sol
+++ b/script/Deploy.gnosh.s.sol
@@ -13,6 +13,7 @@ contract Deploy is Script {
         address deployerAddress
     ) public returns (KeyperSetManager) {
         KeyperSetManager ksm = new KeyperSetManager(deployerAddress);
+        ksm.initialize(deployerAddress, deployerAddress);
 
         // add bootstrap keyper set
         KeyperSet fakeKeyperset = new KeyperSet();

--- a/script/Deploy.gnosh.s.sol
+++ b/script/Deploy.gnosh.s.sol
@@ -13,6 +13,7 @@ contract Deploy is Script {
         address deployerAddress
     ) public returns (KeyperSetManager) {
         KeyperSetManager ksm = new KeyperSetManager(deployerAddress);
+        // otherwise we're not authorized:
         ksm.initialize(deployerAddress, deployerAddress);
 
         // add bootstrap keyper set


### PR DESCRIPTION
`KeyperSetManager` needs to be initialized before `deployer` is allowed to modify it.